### PR TITLE
Allow strings to be keys in the supplied data

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -20,11 +20,11 @@ defmodule Mustache do
         first_scan = List.first(scans)
         variable = first_scan |> clean(["{{", "}}"])
         if escape?(first_scan) do
-          key = variable |> String.strip |> String.to_atom
-          value = data[key] |> to_string |> escape
+          key = variable |> String.strip
+          value = data |> indifferent_access(key) |> to_string |> escape
         else
-          key = String.replace(variable, "&", "") |> String.strip |> String.to_atom
-          value = data[key] |> to_string
+          key = String.replace(variable, "&", "") |> String.strip
+          value = data |> indifferent_access(key) |> to_string
         end
         if value == nil do
           template
@@ -32,6 +32,10 @@ defmodule Mustache do
           double_mustaches(String.replace(template, "{{#{variable}}}", value), data)
         end
     end
+  end
+  
+  def indifferent_access(map, string_key) do
+    map[string_key] || map[string_key |> String.to_atom]
   end
 
   defp scan_for_dot(template, data) do
@@ -51,8 +55,8 @@ defmodule Mustache do
       [] -> template
       _  ->
         variable = List.first(scans) |> clean(["{{{", "}}}"])
-        key = variable |> String.strip |> String.to_atom
-        value = data[key] |> to_string
+        key = variable |> String.strip
+        value = data |> indifferent_access(key) |> to_string
         if value == nil do
           template
         else

--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -94,7 +94,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Ampersand - Standalone" do
-    assert Mustache.render("  {{&string}}\n", % { string: '---' }) == "  ---\n"
+    assert Mustache.render("  {{&string}}\n", %{ string: '---' }) == "  ---\n"
   end
 
    # Whitespace Insensitivity

--- a/test/mustache_integration_test.exs
+++ b/test/mustache_integration_test.exs
@@ -6,6 +6,11 @@ defmodule MustacheTest do
     assert Mustache.render("Hello {{subject}}, my name is {{name}}", data) == "Hello world, my name is John"
   end
 
+  test "String variables preferred over atoms" do
+    data = %{"foo" => "string", :foo => "atom"}
+    assert Mustache.render("This is a {{foo}}", data) == "This is a string"
+  end
+
   test "Multiple triple mustaches" do
     forbidden = %{set1: "& \"", set2: "< >"}
     assert Mustache.render("Not HTML escaped: {{{set1}}} These also not: {{{set2}}}\n", forbidden) == "Not HTML escaped: & \" These also not: < >\n"


### PR DESCRIPTION
If your template is "{{foo}}" then `%{"foo" => "data"}` should work just as
well as `%{foo: "data"}`. It's a bit of an edge case, but if you want to
interpolate user-supplied data into the template, turning the keys into atoms
is inadvisable as they never get GC'ed. If your keys are all strings, the
atoms won't even be tried.