### PR TITLE
Fix method visibility

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -34,7 +34,7 @@ defmodule Mustache do
     end
   end
 
-  def indifferent_access(map, string_key) do
+  defp indifferent_access(map, string_key) do
     map[string_key] || map[string_key |> String.to_atom]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mustache.Mixfile do
 
   def project do
     [app: :mustache,
-     version: "0.3.0",
+     version: "0.3.1",
      elixir: "~> 1.0",
      package: package(),
      description: "Mustache templates for Elixir",


### PR DESCRIPTION
Make `indifferent_access` private. This is only meant for internal use.