### PR TITLE
Various minor fixes

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -39,7 +39,7 @@ defmodule Mustache do
   end
 
   defp scan_for_dot(template, data) do
-    regex = regex("{{", "}}", "\\w+\\.\\w+")
+    regex = regex("{{", "}}", "\\w+(\\.\\w+)+")
     scans = Regex.scan(regex, template) |> List.flatten
     case scans do
       [] -> template

--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -67,7 +67,7 @@ defmodule Mustache do
 
   defp interpolate(template, data, path) do
     value = resolve(data, String.split(path, "."))
-    String.replace(template, "{{#{path}}}", value)
+    String.replace(template, "{{#{path}}}", to_string(value))
   end
 
   defp resolve(data, path) do


### PR DESCRIPTION
Hi guys!

I've fixed two minutes issues I found in the course of using this library:

  1. Interpolation of dotted variable names only works for one level of dotted-ness (i.e. "{{foo.bar}}" works, but "{{foo.bar.baz}}" doesn't)
      - Corrected the regex to correctly match one or more dot-delimited suffixes.
  2. Interpolation of non-string values implementing String.Chars for string serialization does not function as expected.
      - Corrected interpolate/3 to invoke to_string/1 on the value passed to String.replace/3 to ensure all inputs are strings