### PR TITLE
Resolve build warnings of deprecated String.strip/1 method

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -20,10 +20,10 @@ defmodule Mustache do
         first_scan = List.first(scans)
         variable = first_scan |> clean(["{{", "}}"])
         value = if escape?(first_scan) do
-          key = variable |> String.strip
+          key = variable |> String.trim
           data |> indifferent_access(key) |> to_string |> escape
         else
-          key = String.replace(variable, "&", "") |> String.strip
+          key = String.replace(variable, "&", "") |> String.trim
           data |> indifferent_access(key) |> to_string
         end
         if value == nil do
@@ -55,7 +55,7 @@ defmodule Mustache do
       [] -> template
       _  ->
         variable = List.first(scans) |> clean(["{{{", "}}}"])
-        key = variable |> String.strip
+        key = variable |> String.trim
         value = data |> indifferent_access(key) |> to_string
         if value == nil do
           template


### PR DESCRIPTION
I am using your library as a dependency in a personal project, and thought of committing this change to resolve some build warnings.

```
==> mustache
Compiling 1 file (.ex)
warning: String.strip/1 is deprecated, use String.trim/1
  lib/mustache.ex:26

warning: String.strip/1 is deprecated, use String.trim/1
  lib/mustache.ex:23

warning: String.strip/1 is deprecated, use String.trim/1
  lib/mustache.ex:58

Generated mustache app
```

Feel free to ignore or merge at your will.