### PR TITLE
Allow string keys in dot patterns

### DIFF
--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -64,6 +64,16 @@ defmodule MustacheFeatureTest do
               %{person: %{name: "Joe"}}) == "\"Joe\" == \"Joe\""
   end
 
+  test "Dotted Names - String Keys" do
+    assert Mustache.render("\"{{person.name}}\" == \"Joe\"",
+              %{"person" => %{"name" => "Joe"}}) == "\"Joe\" == \"Joe\""
+  end
+
+  test "Dotted Names - Mixed Keys" do
+    assert Mustache.render("\"{{person.name}}\" == \"Joe\"",
+              %{"person" => %{name: "Joe"}}) == "\"Joe\" == \"Joe\""
+  end
+
   @tag :pending
   test "Dotted Names - Basic Interpolation" do
     assert Mustache.render("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"",


### PR DESCRIPTION
There was a previous PR that enabled string keys to be used in the render context, but it only worked for bare variables, not for nested/chained lookups. I've extended that support.

The PR also mentioned avoiding calling `String.to_atom/1` on user input (rightly so), but it didn't remove the call. I've replaced that call with a bit of (maybe unidiomatic, but safer) exception handling. There's a chance for a redundant lookup if the key doesn't exist as an atom, but that exists in the current version as well.