### PR TITLE
Better placeholders

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -26,10 +26,10 @@ defmodule Mustache do
           key = String.replace(variable, "&", "") |> String.trim
           data |> indifferent_access(key) |> to_string
         end
-        if value == nil do
-          template
-        else
-          double_mustaches(String.replace(template, "{{#{variable}}}", value), data)
+        case value do
+          nil -> template
+          "" -> double_mustaches(String.replace(template, "{{#{variable}}}", "**#{variable}**"), data)
+          _ -> double_mustaches(String.replace(template, "{{#{variable}}}", value), data)
         end
     end
   end

--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -46,7 +46,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Basic Context Miss Interpolation" do
-    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I (**can**) be seen!"
+    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I ([[Can]]) be seen!"
   end
 
   test "Triple Mustache Context Miss Interpolation" do
@@ -54,7 +54,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Ampersand Context Miss Interpolation" do
-    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I (**&can**) be seen!"
+    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I ([[Can]]) be seen!"
   end
 
   #Dotted Names

--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -46,7 +46,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Basic Context Miss Interpolation" do
-    assert Mustache.render("I ({{cannot}}) be seen!", %{}) == "I () be seen!"
+    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I (**can**) be seen!"
   end
 
   test "Triple Mustache Context Miss Interpolation" do
@@ -54,7 +54,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Ampersand Context Miss Interpolation" do
-    assert Mustache.render("I ({{&cannot}}) be seen!", %{}) == "I () be seen!"
+    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I (**&can**) be seen!"
   end
 
   #Dotted Names

--- a/test/mustache_integration_test.exs
+++ b/test/mustache_integration_test.exs
@@ -44,4 +44,25 @@ defmodule MustacheTest do
     actual = Mustache.render(template, data)
     assert String.strip(actual) == String.strip(expected)
   end
+
+  test "Renders human readable placeholders for missing keys" do
+    # Basics
+    assert Mustache.render("Hello {{name}}", %{}) == "Hello [[Name]]"
+
+    assert Mustache.render("Hello {{contact.first_name}}", %{}) ==
+             "Hello [[Contact > First name]]"
+
+    assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: "John"}}) ==
+             "Hello John"
+
+    # Complex examples
+    assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{}}) ==
+             "Hello [[Contact > First name]]"
+
+    assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: ""}}) ==
+             "Hello [[Contact > First name]]"
+
+    assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: nil}}) ==
+             "Hello [[Contact > First name]]"
+  end
 end


### PR DESCRIPTION
`[[Contact > First name]]` if the missing key is `contact.first_name`.

This is a product-specific change for our use-case, because this is
currently within a fork. We may want to make this a general option if we
plan to try and merge these changes upstream.